### PR TITLE
Find a way to use nbconvert 6+ to manage templates

### DIFF
--- a/handcalcs/__init__.py
+++ b/handcalcs/__init__.py
@@ -14,6 +14,6 @@
 
 __version__ = "1.2.1" #
 from handcalcs.decorator import handcalc
-from handcalcs.install_templates import install_html, install_latex
+# from handcalcs.install_templates import install_html, install_latex
 __all__ = ["handcalc"]
 

--- a/handcalcs/exporters.py
+++ b/handcalcs/exporters.py
@@ -1,0 +1,31 @@
+from nbconvert import PDFExporter, HTMLExporter, LatexExporter
+
+
+class HTMLHideInputExporter(HTMLExporter):
+    """
+    Exports HTML documents without input cells.
+    """
+
+    export_from_notebook = "HTML Hide Input"
+    exclude_input = HTMLExporter.exclude_input
+    exclude_input.default_value = True
+
+
+class PDFHideInputExporter(PDFExporter):
+    """
+    Exports PDF documents without input cells.
+    """
+
+    export_from_notebook = "PDF Hide Input"
+    exclude_input = PDFExporter.exclude_input
+    exclude_input.default_value = True
+
+
+class LatexHideInputExporter(LatexExporter):
+    """
+    Exports LaTeX documents without input cells.
+    """
+
+    export_from_notebook = "LaTeX Hide Input"
+    exclude_input = LatexExporter.exclude_input
+    exclude_input.default_value = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ nbconvert = "^5.6.1"
 pytest-cov = "^2.9.0"
 coverage = {extras = ["toml"], version = "^5.1"}
 jupyterlab = "^2.1.5"
-nbconvert = "^5.6.1"
+nbconvert = "^6.0.0"
 pdbpp = "^0.10.2"
 ipython = "^7.18.1"
 sympy = "^1.6.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyparsing>=2.4.0
 innerscope >= 0.2.0
 more-itertools >= 8.5.0
-nbconvert == 5.6.1
+nbconvert >= 6.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ VERSION = '1.2.1'
 # What packages are required for this module to be executed?
 REQUIRED = [
     'pyparsing',
+    'nbconvert>=6.0.0',
     'innerscope >= 0.2.0',
     'more-itertools >= 8.5.0'
     # 'requests', 'maya', 'records',
@@ -109,12 +110,14 @@ setup(
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     package_data={'': ['*.json']},
     include_package_data=True,
-    # If your package is a single module, use this instead of 'packages':
-    #py_modules=['forallpeople'],
+    entry_points={
+        'nbconvert.exporters': [
+            'HTML_noinput  = handcalcs.exporters:HTMLHideInputExporter',
+            'PDF_noinput  = handcalcs.exporters:PDFHideInputExporter',
+            'LaTeX_noinput  = handcalcs.exporters:LatexHideInputExporter',
+        ],
+    },
 
-    # entry_points={
-    #     'console_scripts': ['mycli=mymodule:cli'],
-    # },
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     license='GNU General Public License v3 (GPLv3)',

--- a/test_handcalcs/test_handcalcs_file.py
+++ b/test_handcalcs/test_handcalcs_file.py
@@ -15,6 +15,9 @@
 
 import inspect
 from collections import deque
+
+from handcalcs.exporters import LatexHideInputExporter, HTMLHideInputExporter, PDFHideInputExporter
+
 import handcalcs
 import pathlib
 import pytest
@@ -277,60 +280,87 @@ def test_handcalcs3():
 # Test template.py
 
 
-def test_install_latex(capsys):
-    HERE = pathlib.Path(__file__).resolve().parent
-    TEMPLATES = HERE.parent / "handcalcs" / "templates"
-    MAIN_TEMPLATE = TEMPLATES / "latex" / "t-makaro_classic_romanoutput_noinput.tplx"
-    NBCONVERT_TEMPLATES_DIR = (
-        pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "latex"
-    )
+def test_latex_exporter():
+    """
 
-    install_latex()
-    captured = capsys.readouterr()
-    assert (
-        captured.out
-        == "Available templates: \n ['t-makaro_classic_romanoutput_noinput.tplx']\n"
-    )
-    install_latex(swap_in="t-makaro_classic_romanoutput_noinput.tplx")
-    assert filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "article.tplx")
+    """
+
+    exporter = LatexHideInputExporter()
+    assert exporter.exclude_input == True
 
 
-def test_install_latex_restore():
-    HERE = pathlib.Path(__file__).resolve().parent
-    TEMPLATES = HERE.parent / "handcalcs" / "templates"
-    MAIN_TEMPLATE = TEMPLATES / "latex" / "t-makaro_classic_romanoutput_noinput.tplx"
-    NBCONVERT_TEMPLATES_DIR = (
-        pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "latex"
-    )
+def test_pdf_exporter():
+    """
 
-    install_latex(restore=True)
-    assert not filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "article.tplx")
+    """
+
+    exporter = PDFHideInputExporter()
+    assert exporter.exclude_input == True
 
 
-def test_install_html(capsys):
-    HERE = pathlib.Path(__file__).resolve().parent
-    TEMPLATES = HERE.parent / "handcalcs" / "templates"
-    MAIN_TEMPLATE = TEMPLATES / "html" / "full_html_noinputs.tpl"
-    NBCONVERT_TEMPLATES_DIR = (
-        pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "html"
-    )
+def test_html_exporter():
+    """
 
-    install_html()
-    captured = capsys.readouterr()
-    assert captured.out == "Available templates: \n ['full_html_noinputs.tpl']\n"
-    install_html(swap_in="full_html_noinputs.tpl")
-    assert filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "full.tpl")
+    """
+
+    exporter = HTMLHideInputExporter()
+    assert exporter.exclude_input == True
 
 
-def test_install_html_restore():
-    HERE = pathlib.Path(__file__).resolve().parent
-    TEMPLATES = HERE.parent / "handcalcs" / "templates"
-    MAIN_TEMPLATE = TEMPLATES / "html" / "full_html_noinputs.tpl"
-    NBCONVERT_TEMPLATES_DIR = (
-        pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "html"
-    )
-    install_html(restore=True)
-    assert not filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "full.tpl")
+# def test_install_latex(capsys):
+#     HERE = pathlib.Path(__file__).resolve().parent
+#     TEMPLATES = HERE.parent / "handcalcs" / "templates"
+#     MAIN_TEMPLATE = TEMPLATES / "latex" / "t-makaro_classic_romanoutput_noinput.tplx"
+#     NBCONVERT_TEMPLATES_DIR = (
+#         pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "latex"
+#     )
+#
+#     install_latex()
+#     captured = capsys.readouterr()
+#     assert (
+#         captured.out
+#         == "Available templates: \n ['t-makaro_classic_romanoutput_noinput.tplx']\n"
+#     )
+#     install_latex(swap_in="t-makaro_classic_romanoutput_noinput.tplx")
+#     assert filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "article.tplx")
+#
+#
+# def test_install_latex_restore():
+#     HERE = pathlib.Path(__file__).resolve().parent
+#     TEMPLATES = HERE.parent / "handcalcs" / "templates"
+#     MAIN_TEMPLATE = TEMPLATES / "latex" / "t-makaro_classic_romanoutput_noinput.tplx"
+#     NBCONVERT_TEMPLATES_DIR = (
+#         pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "latex"
+#     )
+#
+#     install_latex(restore=True)
+#     assert not filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "article.tplx")
+#
+#
+# def test_install_html(capsys):
+#     HERE = pathlib.Path(__file__).resolve().parent
+#     TEMPLATES = HERE.parent / "handcalcs" / "templates"
+#     MAIN_TEMPLATE = TEMPLATES / "html" / "full_html_noinputs.tpl"
+#     NBCONVERT_TEMPLATES_DIR = (
+#         pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "html"
+#     )
+#
+#     install_html()
+#     captured = capsys.readouterr()
+#     assert captured.out == "Available templates: \n ['full_html_noinputs.tpl']\n"
+#     install_html(swap_in="full_html_noinputs.tpl")
+#     assert filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "full.tpl")
+#
+#
+# def test_install_html_restore():
+#     HERE = pathlib.Path(__file__).resolve().parent
+#     TEMPLATES = HERE.parent / "handcalcs" / "templates"
+#     MAIN_TEMPLATE = TEMPLATES / "html" / "full_html_noinputs.tpl"
+#     NBCONVERT_TEMPLATES_DIR = (
+#         pathlib.Path(nbconvert.__file__).resolve().parent / "templates" / "html"
+#     )
+#     install_html(restore=True)
+#     assert not filecmp.cmp(MAIN_TEMPLATE, NBCONVERT_TEMPLATES_DIR / "full.tpl")
 
 
 # Test expected exceptions


### PR DESCRIPTION
The changes I adopted in this pull request are:
- Added custom exporters to exporters.py
- Registered custom exporters using entry points in setup.py
- Updated nbconvert requirements to >=6.0

I also added three trivial tests and commented out the old install template tests. Have a look if this is sufficient for you to drop the nbconvert 5.6 requirement. 